### PR TITLE
Add the link to the collaborative document

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -27,6 +27,7 @@ The workshop will be held online.
 **Before signing** up please also read
 [this privacy note about tools/services we use](requirements/#privacy-and-tools-online-services).
 
+**Collaborative Document**: https://pad.carpentries.org/2022-01-27-nist-branching-online
 
 ## Schedule
 


### PR DESCRIPTION
Update website to include collaborative document for future reference. Useful when setting up future etherpads to have access to past versions or for participants to refer back to in future if they lose the link.